### PR TITLE
feat: Add product name property support

### DIFF
--- a/src/Uno.DevTools.Telemetry/Telemetry.cs
+++ b/src/Uno.DevTools.Telemetry/Telemetry.cs
@@ -34,6 +34,7 @@ namespace Uno.DevTools.Telemetry
         private string _instrumentationKey;
         private string _eventNamePrefix;
         private readonly Assembly _versionAssembly;
+        private readonly string? _productName;
         private readonly Func<string>? _currentDirectoryProvider;
         private const string TelemetryOptout = "UNO_PLATFORM_TELEMETRY_OPTOUT";
 
@@ -48,6 +49,7 @@ namespace Uno.DevTools.Telemetry
         /// <param name="blockThreadInitialization">Block the execution of the constructor until the telemetry is initialized</param>
         /// <param name="sessionId">Defines the session ID for this instance</param>
         /// <param name="versionAssembly">The assembly to use to get the version to report in telemetry</param>
+        /// <param name="productName">The product name to use in the common properties. If null, versionAssembly.Name is used instead.</param>
         public Telemetry(
             string instrumentationKey,
             string eventNamePrefix,
@@ -55,12 +57,14 @@ namespace Uno.DevTools.Telemetry
             string? sessionId = null,
             bool blockThreadInitialization = false,
             Func<bool?>? enabledProvider = null,
-            Func<string>? currentDirectoryProvider = null)
+            Func<string>? currentDirectoryProvider = null,
+            string? productName = null)
         {
             _instrumentationKey = instrumentationKey;
             _currentDirectoryProvider = currentDirectoryProvider;
             _eventNamePrefix = eventNamePrefix;
             _versionAssembly = versionAssembly;
+            _productName = productName;
 
             if (bool.TryParse(Environment.GetEnvironmentVariable(TelemetryOptout), out var telemetryOptOut))
             {
@@ -172,7 +176,12 @@ namespace Uno.DevTools.Telemetry
 
                 _persistenceChannel.SendingInterval = TimeSpan.FromMilliseconds(1);
 
-                _commonProperties = new TelemetryCommonProperties(_settingsStorageDirectoryPath, _versionAssembly, _currentDirectoryProvider).GetTelemetryCommonProperties();
+                _commonProperties = new TelemetryCommonProperties(
+                    _settingsStorageDirectoryPath,
+                    _versionAssembly,
+                    _productName ?? _versionAssembly.GetName().Name ?? "Unknown",
+                    _currentDirectoryProvider
+                    ).GetTelemetryCommonProperties();
                 _commonMeasurements = new Dictionary<string, double>();
 
                 _telemetryConfig = new TelemetryConfiguration {

--- a/src/Uno.DevTools.Telemetry/TelemetryCommonProperties.cs
+++ b/src/Uno.DevTools.Telemetry/TelemetryCommonProperties.cs
@@ -31,16 +31,19 @@ namespace Uno.DevTools.Telemetry
         public TelemetryCommonProperties(
             string storageDirectoryPath,
             Assembly versionAssembly,
+            string productName,
             Func<string>? getCurrentDirectory = null)
         {
             _getCurrentDirectory = getCurrentDirectory ?? Directory.GetCurrentDirectory;
             _storageDirectoryPath = storageDirectoryPath;
             _versionAssembly = versionAssembly;
+            _productName = productName;
         }
 
         private Func<string> _getCurrentDirectory;
         private string _storageDirectoryPath;
         private readonly Assembly _versionAssembly;
+        private readonly string _productName;
 
         public const string OSVersion = "OS Version";
         public const string OSPlatform = "OS Platform";
@@ -49,6 +52,7 @@ namespace Uno.DevTools.Telemetry
         public const string RuntimeId = "Runtime Id";
         public const string MachineId = "Machine ID";
         public const string ProductVersion = "Product Version";
+        public const string ProductName = "Product Name";
         public const string TelemetryProfile = "Telemetry Profile";
         public const string CurrentPathHash = "Current Path Hash";
         public const string KernelVersion = "Kernel Version";
@@ -67,6 +71,7 @@ namespace Uno.DevTools.Telemetry
                 { OutputRedirected, Console.IsOutputRedirected.ToString() },
                 { RuntimeId, RuntimeEnvironment.GetRuntimeIdentifier() },
                 { ProductVersion, GetProductVersion() },
+                { ProductName, _productName },
                 { TelemetryProfile, Environment.GetEnvironmentVariable(TelemetryProfileEnvironmentVariable) ?? "" },
                 { MachineId, GetMachineId() },
                 { CurrentPathHash, HashBuilder.Build(_getCurrentDirectory()) },
@@ -168,7 +173,6 @@ namespace Uno.DevTools.Telemetry
 
             return "Unknown";
         }
-
 
         /// <summary>
         /// Returns a string identifying the OS kernel.


### PR DESCRIPTION
Add support for product name discrimination. Uses the assembly name by default.