### PR TITLE
fix(ci): add Linux host disk cleanup for CI builds

### DIFF
--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -1,0 +1,19 @@
+name: 'Host Cleanup (Linux)'
+description: 'Remove unused toolchains and SDKs to free disk space on Linux runners'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cleanup unused image dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "Disk space before cleanup:"
+        df -h /
+        rm -fR ~/.cargo ~/.rustup ~/.dotnet
+        sudo rm -fR /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo snap remove lxd || true
+        sudo snap remove core20 || true
+        sudo apt remove -y snapd || true
+        echo "Disk space after cleanup:"
+        df -h /

--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -1,19 +1,40 @@
-name: 'Host Cleanup (Linux)'
-description: 'Remove unused toolchains and SDKs to free disk space on Linux runners'
+name: Host Cleanup (Linux)
+description: Reclaims disk space on Linux CI agents by removing unused pre-installed software
 
 runs:
   using: 'composite'
   steps:
-    - name: Cleanup unused image dependencies
+    - name: Cleanup unused host dependencies
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # This list is based on what the base image contains and
+        # may need to be adjusted as new software gets installed.
+        # Use the `du` command to determine what can be uninstalled.
+
+        # Use sudo only when available (containers may not have it)
+        if command -v sudo >/dev/null 2>&1; then
+          SUDO="sudo"
+        else
+          SUDO=""
+        fi
+
         echo "Disk space before cleanup:"
         df -h /
-        rm -fR ~/.cargo ~/.rustup ~/.dotnet
-        sudo rm -fR /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        sudo snap remove lxd || true
-        sudo snap remove core20 || true
-        sudo apt remove -y snapd || true
+
+        rm -rf ~/.cargo ~/.rustup ~/.dotnet
+
+        $SUDO rm -rf /usr/share/swift || true
+        $SUDO rm -rf /opt/microsoft/msedge || true
+        $SUDO rm -rf /usr/local/.ghcup || true
+        $SUDO rm -rf /usr/lib/mono || true
+        $SUDO rm -rf /usr/local/lib/android || true
+        $SUDO rm -rf /opt/ghc || true
+        $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
+
+        $SUDO snap remove lxd || true
+        $SUDO snap remove core20 || true
+        $SUDO apt-get purge -y snapd || true
+
         echo "Disk space after cleanup:"
         df -h /

--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -12,9 +12,9 @@ runs:
         # may need to be adjusted as new software gets installed.
         # Use the `du` command to determine what can be uninstalled.
 
-        # Use sudo only when available (containers may not have it)
-        if command -v sudo >/dev/null 2>&1; then
-          SUDO="sudo"
+        # Use sudo only when available and non-interactive (no password prompt)
+        if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+          SUDO="sudo -n"
         else
           SUDO=""
         fi
@@ -22,7 +22,7 @@ runs:
         echo "Disk space before cleanup:"
         df -h /
 
-        rm -rf ~/.cargo ~/.rustup ~/.dotnet
+        rm -rf ~/.cargo ~/.rustup ~/.dotnet || true
 
         $SUDO rm -rf /usr/share/swift || true
         $SUDO rm -rf /opt/microsoft/msedge || true
@@ -32,9 +32,14 @@ runs:
         $SUDO rm -rf /opt/ghc || true
         $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
 
-        $SUDO snap remove lxd || true
-        $SUDO snap remove core20 || true
-        $SUDO apt-get purge -y snapd || true
+        if command -v snap >/dev/null 2>&1; then
+          timeout 60s $SUDO snap remove lxd || true
+          timeout 60s $SUDO snap remove core20 || true
+        fi
+
+        if command -v apt-get >/dev/null 2>&1; then
+          DEBIAN_FRONTEND=noninteractive timeout 120s $SUDO apt-get purge -y snapd || true
+        fi
 
         echo "Disk space after cleanup:"
         df -h /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Free disk space (Linux)
+      uses: ./.github/actions/host-cleanup-linux
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
## What
Adds a Linux host disk cleanup step to all Linux CI jobs to reclaim disk space by removing unused pre-installed software.

## Why
Linux CI agents accumulate ~20–30 GB of pre-installed software (Cargo, Rust, Swift, Edge, GHC, Mono, Android SDK, CodeQL, snapd) that is not needed for builds. This cleanup step runs at the start of each Linux job to ensure sufficient disk space.

## Details
- Adds a GHA composite action (`.github/actions/host-cleanup-linux/action.yml`) with inline cleanup script
- Cleanup is conditional on Linux (`if: runner.os == 'Linux'`)
- Uses `sudo -n` (non-interactive) probe to work safely in both host and container environments
- All removals are best-effort (`|| true`) with `timeout` guards on snap/apt-get commands
- Uses `DEBIAN_FRONTEND=noninteractive` for apt-get to prevent dpkg prompts

Part of org-wide CI disk cleanup initiative.
Related to https://github.com/unoplatform/uno.rider/pull/480