### PR TITLE
ci: add package version to job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
         name: NuGet
         path: .\artifacts
 
+    - name: Add NuGet Summary
+      shell: pwsh
+      run: |
+        echo "### NuGet Package Summary" >> $env:GITHUB_STEP_SUMMARY
+        echo "Package version: $env:NBGV_SemVer2" >> $env:GITHUB_STEP_SUMMARY
+
     - name: Create Test Results Directory
       shell: pwsh
       run: New-Item -ItemType Directory -Force -Path artifacts/test-results


### PR DESCRIPTION
Adds an NuGet Package Summary step to the CI build job that writes the package version (from nbgv) to the GitHub Actions job summary, matching the pattern used in uno.templates and other repos.